### PR TITLE
feat: сделал компонент с выбором чекбоксов

### DIFF
--- a/src/shared/assets/icons/check-mark.svg
+++ b/src/shared/assets/icons/check-mark.svg
@@ -1,3 +1,3 @@
 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M2.51367 8.26792L7.23304 14.7154C7.61813 15.2415 8.39556 15.2644 8.81085 14.7618L17.4984 4.24805" stroke="#2C2A29" stroke-width="1.3" stroke-linecap="round"/>
+<path d="M2.51367 8.26792L7.23304 14.7154C7.61813 15.2415 8.39556 15.2644 8.81085 14.7618L17.4984 4.24805" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
 </svg>

--- a/src/shared/ui/button/button-variants.tsx
+++ b/src/shared/ui/button/button-variants.tsx
@@ -15,9 +15,12 @@ export const buttonVariants = cva(
         destructive:
           "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
         link: "text-primary underline-offset-4 hover:underline",
+        plain:
+          "bg-transparent hover:bg-muted hover:text-inherit aria-expanded:bg-transparent aria-expanded:hover:bg-muted",
       },
       size: {
         default: "h-8 gap-1.5 px-2.5",
+        plain: "h-auto gap-0 p-0",
         xs: "h-6 gap-1 px-2 text-xs",
         sm: "h-7 gap-1 px-2.5 text-[0.8rem]",
         lg: "h-9 gap-1.5 px-2.5",

--- a/src/shared/ui/button/button-variants.tsx
+++ b/src/shared/ui/button/button-variants.tsx
@@ -15,8 +15,7 @@ export const buttonVariants = cva(
         destructive:
           "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
         link: "text-primary underline-offset-4 hover:underline",
-        plain:
-          "bg-transparent hover:bg-muted hover:text-inherit aria-expanded:bg-transparent aria-expanded:hover:bg-muted",
+        plain: "bg-transparent hover:text-inherit",
       },
       size: {
         default: "h-8 gap-1.5 px-2.5",

--- a/src/shared/ui/checkbox-select/checkbox-select.tsx
+++ b/src/shared/ui/checkbox-select/checkbox-select.tsx
@@ -62,7 +62,7 @@ export const CheckboxSelect = ({
 
           return (
             <li key={option.value}>
-              <label className="flex items-center gap-2">
+              <label className="flex items-center gap-2 cursor-pointer">
                 <Checkbox
                   checked={checked}
                   disabled={option.disabled}
@@ -87,7 +87,7 @@ export const CheckboxSelect = ({
         <Button
           variant="plain"
           size="plain"
-          className="flex justify-between w-full"
+          className="flex justify-between w-full hover:text-primary"
         >
           <span className="text-(length:--font-size-body-m)">{title}</span>
           {open ? (
@@ -108,7 +108,7 @@ export const CheckboxSelect = ({
                 <Button
                   variant="plain"
                   size="plain"
-                  className="font-(--font-weight-regular) text-(--color-gray-600)"
+                  className="font-(--font-weight-regular) text-muted-foreground"
                 >
                   {`Показать все (${hiddenOptionsCount})`}
                 </Button>
@@ -123,7 +123,7 @@ export const CheckboxSelect = ({
                   <Button
                     variant="plain"
                     size="plain"
-                    className="font-(--font-weight-regular) text-(--color-gray-600)"
+                    className="font-(--font-weight-regular) text-muted-foreground"
                   >
                     {`Скрыть`}
                   </Button>

--- a/src/shared/ui/checkbox-select/checkbox-select.tsx
+++ b/src/shared/ui/checkbox-select/checkbox-select.tsx
@@ -1,0 +1,138 @@
+import { useState } from "react";
+import { Checkbox } from "@ui/checkbox";
+import { Button } from "@ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@ui/collapsible";
+
+import ArrowDownIcon from "@icons/arrow-down.svg?react";
+import ArrowUpIcon from "@icons/arrow-up.svg?react";
+
+type TCheckboxSelectOption = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+};
+
+type TCheckboxSelectProps = {
+  options: TCheckboxSelectOption[];
+  value: string[];
+  onValueChange: (value: string[]) => void;
+  visibleCount?: number;
+  title?: string;
+};
+
+export const CheckboxSelect = ({
+  options,
+  value,
+  onValueChange,
+  visibleCount = 4,
+  title = "Выберите",
+}: TCheckboxSelectProps) => {
+  const [open, setIsOpen] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  const visibleOptions = options.slice(0, visibleCount);
+  const hiddenOptions = options.slice(visibleCount);
+  const hiddenOptionsCount = hiddenOptions.length;
+
+  const handleChecked = (optionValue: string, checked: boolean) => {
+    if (checked) {
+      onValueChange([...value, optionValue]);
+      return;
+    }
+
+    onValueChange(value.filter((item) => item !== optionValue));
+  };
+
+  const handleOpen = (openState: boolean) => {
+    setIsOpen(openState);
+    if (!openState) {
+      setExpanded(false);
+    }
+  };
+
+  const renderOptions = (options: TCheckboxSelectOption[]) => {
+    return (
+      <ul className="flex flex-col gap-3.5 mb-3.5">
+        {options.map((option) => {
+          const checked = value.includes(option.value);
+
+          return (
+            <li key={option.value}>
+              <label className="flex items-center gap-2">
+                <Checkbox
+                  checked={checked}
+                  disabled={option.disabled}
+                  onCheckedChange={(checked) =>
+                    handleChecked(option.value, checked === true)
+                  }
+                />
+                <span className="text-(length:--font-size-body-s)">
+                  {option.label}
+                </span>
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+    );
+  };
+
+  return (
+    <Collapsible open={open} onOpenChange={handleOpen} className="w-full">
+      <CollapsibleTrigger asChild className="mb-2.75">
+        <Button
+          variant="plain"
+          size="plain"
+          className="flex justify-between w-full"
+        >
+          <span className="text-(length:--font-size-body-m)">{title}</span>
+          {open ? (
+            <ArrowUpIcon className="size-5" />
+          ) : (
+            <ArrowDownIcon className="size-5" />
+          )}
+        </Button>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent>
+        {renderOptions(visibleOptions)}
+
+        {hiddenOptionsCount > 0 && (
+          <Collapsible open={expanded} onOpenChange={setExpanded}>
+            {!expanded && (
+              <CollapsibleTrigger asChild>
+                <Button
+                  variant="plain"
+                  size="plain"
+                  className="font-(--font-weight-regular) text-(--color-gray-600)"
+                >
+                  {`Показать все (${hiddenOptionsCount})`}
+                </Button>
+              </CollapsibleTrigger>
+            )}
+
+            <CollapsibleContent>
+              {renderOptions(hiddenOptions)}
+
+              {expanded && (
+                <CollapsibleTrigger asChild>
+                  <Button
+                    variant="plain"
+                    size="plain"
+                    className="font-(--font-weight-regular) text-(--color-gray-600)"
+                  >
+                    {`Скрыть`}
+                  </Button>
+                </CollapsibleTrigger>
+              )}
+            </CollapsibleContent>
+          </Collapsible>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};

--- a/src/shared/ui/checkbox-select/index.ts
+++ b/src/shared/ui/checkbox-select/index.ts
@@ -1,0 +1,1 @@
+export { CheckboxSelect } from "./checkbox-select";

--- a/src/shared/ui/checkbox/checkbox.tsx
+++ b/src/shared/ui/checkbox/checkbox.tsx
@@ -1,0 +1,30 @@
+import { Checkbox as CheckboxPrimitive } from "radix-ui";
+
+import { cn } from "@/shared/lib";
+import CheckIcon from "@/shared/assets/icons/check-mark.svg?react";
+import type { ComponentProps } from "react";
+
+function Checkbox({
+  className,
+  ...props
+}: ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer relative flex size-5 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
+      >
+        <CheckIcon className="text-(--color-white)" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/src/shared/ui/checkbox/index.ts
+++ b/src/shared/ui/checkbox/index.ts
@@ -1,0 +1,1 @@
+export { Checkbox } from "./checkbox";


### PR DESCRIPTION
Таска #42 
1) Добавил компонент Checkbox из shadcn, чуть его изменил под наш макет (размеры и иконка галочки).
2) Сделал компонент CheckboxSelect на основе Checkbox и компонента Collapsible, который уже был в проекте. Компонент занимает всю ширину контейнера (для примера пока что в home-page оставил его для проверки, уберу при мердже). CheckboxSelect принимает тайтл, который отображается в его хедере, список опций, и количество видимых элементов (по умолчанию 4). Отдает наружу массив строк value, которые меняются через родительский стейт.
3) В ui компонент Button, добавил "простой" вариант для кнопки без паддингов и лишних стилей, чтоб использовать его в Collapsible.