### PR TITLE
Fix/141 adaptive 992

### DIFF
--- a/src/features/create-employee/ui/create-employee-button.tsx
+++ b/src/features/create-employee/ui/create-employee-button.tsx
@@ -5,22 +5,29 @@ import { cn } from "@/shared/lib";
 interface CreateEmployeeButtonProps {
   onClick: () => void;
   className?: string;
+  hideLabelOnCompact?: boolean;
 }
 
 export const CreateEmployeeButton = ({
   onClick,
   className,
+  hideLabelOnCompact = false,
 }: CreateEmployeeButtonProps) => {
   return (
     <Button
       onClick={onClick}
+      aria-label="Добавить карточку"
       className={cn(
         "gap-2 w-[197px] h-[40px] text-xs tracking-[-0.5px] bg-purple-500 hover:bg-purple-600 text-white rounded-[var(--radius-8)]",
         className,
       )}
     >
-      <PlusIcon className="size-3" />
-      Добавить карточку
+      <PlusIcon
+        className={cn("size-3", hideLabelOnCompact && "max-[1100px]:size-4")}
+      />
+      <span className={hideLabelOnCompact ? "max-[1100px]:sr-only" : ""}>
+        Добавить карточку
+      </span>
     </Button>
   );
 };

--- a/src/features/create-employee/ui/create-employee-wrapper.tsx
+++ b/src/features/create-employee/ui/create-employee-wrapper.tsx
@@ -4,7 +4,15 @@ import { CreateEmployeeDialog } from "./create-employee-dialog";
 import type { CreateEmployeeFormValues } from "../model/types";
 import { useCreateEmployee } from "@/entities/employee";
 
-export const CreateEmployeeWrapper = () => {
+interface CreateEmployeeWrapperProps {
+  buttonClassName?: string;
+  hideButtonLabelOnCompact?: boolean;
+}
+
+export const CreateEmployeeWrapper = ({
+  buttonClassName,
+  hideButtonLabelOnCompact = false,
+}: CreateEmployeeWrapperProps) => {
   const [open, setOpen] = useState(false);
   //TODO: Обработать сценарий если при создании происходит ошибка
   const { mutate } = useCreateEmployee();
@@ -25,7 +33,11 @@ export const CreateEmployeeWrapper = () => {
 
   return (
     <>
-      <CreateEmployeeButton onClick={() => setOpen(true)} />
+      <CreateEmployeeButton
+        onClick={() => setOpen(true)}
+        className={buttonClassName}
+        hideLabelOnCompact={hideButtonLabelOnCompact}
+      />
       <CreateEmployeeDialog
         open={open}
         onOpenChange={setOpen}

--- a/src/pages/employees/employees-page.tsx
+++ b/src/pages/employees/employees-page.tsx
@@ -87,7 +87,7 @@ const EmployeesPage = () => {
 
   return (
     <>
-      <div className="bg-gray-50 min-h-screen">
+      <div className="flex h-full min-h-0 flex-col bg-gray-50">
         <PageHeader
           title="Книга сотрудников"
           stats={<span>144 сотрудников, 4 направления, 7 СИС</span>}
@@ -98,7 +98,7 @@ const EmployeesPage = () => {
           user={<HeaderUserCard />}
         />
 
-        <div className="px-10 pt-5 grid grid-cols-[295px_minmax(0,1fr)] gap-x-7 min-h-screen max-[1100px]:px-5">
+        <div className="grid min-h-0 flex-1 grid-cols-[295px_minmax(0,1fr)] gap-x-7 px-10 pt-5 max-[1100px]:px-5">
           <Navbar />
 
           <div className="space-y-3">

--- a/src/pages/employees/employees-page.tsx
+++ b/src/pages/employees/employees-page.tsx
@@ -98,7 +98,7 @@ const EmployeesPage = () => {
           user={<HeaderUserCard />}
         />
 
-        <div className="mx-10 mt-5 grid grid-cols-[295px_1fr] gap-x-7 min-h-screen">
+        <div className="mx-10 mt-5 grid grid-cols-[295px_minmax(0,1fr)] gap-x-7 min-h-screen">
           <Navbar />
 
           <div className="space-y-3">

--- a/src/pages/employees/employees-page.tsx
+++ b/src/pages/employees/employees-page.tsx
@@ -98,7 +98,7 @@ const EmployeesPage = () => {
           user={<HeaderUserCard />}
         />
 
-        <div className="mx-10 mt-5 grid grid-cols-[295px_minmax(0,1fr)] gap-x-7 min-h-screen">
+        <div className="px-10 pt-5 grid grid-cols-[295px_minmax(0,1fr)] gap-x-7 min-h-screen max-[1100px]:px-5">
           <Navbar />
 
           <div className="space-y-3">

--- a/src/pages/org-structure/org-structure-page.tsx
+++ b/src/pages/org-structure/org-structure-page.tsx
@@ -16,15 +16,15 @@ const OrgStructurePage = () => {
   const isZoomabled = zoom > 100;
 
   return (
-    <div>
+    <div className="flex h-full min-h-0 flex-col">
       <PageHeader
         title="Оргструктура"
         stats={<span>144 сотрудников, 4 направления, 7 СИС</span>}
         birthday={<BirthdaysPopover />}
         user={<HeaderUserCard />}
       />
-      <main className="h-screen pt-5 pb-10 px-10 flex flex-col gap-5 max-[1100px]:px-5">
-        <div className="flex justify-start gap-7">
+      <main className="flex min-h-0 flex-1 flex-col gap-5 px-10 pt-5 pb-10 max-[1100px]:px-5">
+        <div className="flex shrink-0 justify-start gap-7">
           {isAdmin && (
             <Button variant="outline" onClick={() => setIsClarifyingOpen(true)}>
               Загрузить схему
@@ -41,7 +41,7 @@ const OrgStructurePage = () => {
             </Button>
           )}
         </div>
-        <div className="border rounded-2xl border-border overflow-hidden flex-1 min-h-0">
+        <div className="min-h-0 flex-1 overflow-hidden">
           <OrgStructureChart zoom={zoom} />
         </div>
       </main>

--- a/src/pages/org-structure/org-structure-page.tsx
+++ b/src/pages/org-structure/org-structure-page.tsx
@@ -23,7 +23,7 @@ const OrgStructurePage = () => {
         birthday={<BirthdaysPopover />}
         user={<HeaderUserCard />}
       />
-      <main className="h-screen pt-5 pb-10 px-10 flex flex-col gap-5">
+      <main className="h-screen pt-5 pb-10 px-10 flex flex-col gap-5 max-[1100px]:px-5">
         <div className="flex justify-start gap-7">
           {isAdmin && (
             <Button variant="outline" onClick={() => setIsClarifyingOpen(true)}>
@@ -42,7 +42,7 @@ const OrgStructurePage = () => {
           )}
         </div>
         <div className="border rounded-2xl border-border overflow-hidden flex-1 min-h-0">
-          <OrgStructureChart zoom={zoom}/>
+          <OrgStructureChart zoom={zoom} />
         </div>
       </main>
       <ClarifyingModal

--- a/src/shared/ui/pagination/app-pagination.tsx
+++ b/src/shared/ui/pagination/app-pagination.tsx
@@ -158,7 +158,7 @@ export const AppPagination = ({
 
       <div className="flex flex-1 justify-end">
         <div className="flex items-center gap-2 whitespace-nowrap body-overline">
-          <span>Карточек на странице:</span>
+          <span className="max-[1300px]:hidden">Карточек на странице:</span>
 
           <DropdownMenu>
             <DropdownMenuTrigger hasArrow className="px-2">

--- a/src/shared/ui/zoomable-image/zoomable-image.tsx
+++ b/src/shared/ui/zoomable-image/zoomable-image.tsx
@@ -22,6 +22,8 @@ export const ZoomableImage = ({ src, alt, zoom }: ZoomableImageProps) => {
   const objectViewBox = `inset(${insetY * 100}% ${(1 - insetX - size) * 100}% ${(1 - insetY - size) * 100}% ${insetX * 100}%)`;
 
   const handleMouseDown = (e: React.MouseEvent) => {
+    if (zoom <= 100) return;
+
     dragStart.current = {
       mouseX: e.clientX,
       mouseY: e.clientY,
@@ -31,7 +33,8 @@ export const ZoomableImage = ({ src, alt, zoom }: ZoomableImageProps) => {
   };
 
   const handleMouseMove = (e: React.MouseEvent<HTMLImageElement>) => {
-    if (!dragStart.current) return;
+    if (!dragStart.current || zoom <= 100) return;
+
     const dx =
       (dragStart.current.mouseX - e.clientX) / e.currentTarget.clientWidth;
     const dy =
@@ -55,9 +58,10 @@ export const ZoomableImage = ({ src, alt, zoom }: ZoomableImageProps) => {
       onMouseMove={handleMouseMove}
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseUp}
-      className="w-full h-full select-none"
+      className="block h-auto max-h-full w-full select-none rounded-2xl border border-border min-[1600px]:mx-auto min-[1600px]:h-full min-[1600px]:w-auto min-[1600px]:max-w-full"
       style={{
-        objectFit: "cover",
+        objectFit: zoom > 100 ? "cover" : "contain",
+        objectPosition: "top left",
         objectViewBox,
         cursor: zoom > 100 ? "grab" : "default",
       }}

--- a/src/widgets/employees-filter-bar/employees-filter-bar.tsx
+++ b/src/widgets/employees-filter-bar/employees-filter-bar.tsx
@@ -76,7 +76,7 @@ export const EmployeesFilterBar = () => {
   };
 
   return (
-    <div className="flex items-center gap-3 flex-nowrap">
+    <div className="flex items-center gap-3 flex-wrap">
       <StatusFilter value={statusFilter} onValueChange={setStatusFilter} />
       <FilterCities
         options={citiesFilterOptions}
@@ -93,21 +93,30 @@ export const EmployeesFilterBar = () => {
         getAllEmployees={getAllEmployees}
       />
 
-      <div className="ml-auto" />
+      <div className="hidden flex-1 min-[1150px]:block" />
 
       <div className="flex items-center gap-3">
         {viewType === "list" && (
           <Button
             variant="outline"
             size="default"
-            className="gap-2"
+            className="gap-2 max-[1100px]:size-8 max-[1100px]:w-24 max-[1100px]:gap-0 max-[1100px]:px-0"
             onClick={onExportClick}
           >
             <ExportIcon className="size-5" />
-            Экспортировать
+            <span className="max-[1100px]:sr-only">Экспортировать</span>
           </Button>
         )}
-        {isAdmin && <CreateEmployeeWrapper />}
+        {isAdmin && (
+          <CreateEmployeeWrapper
+            buttonClassName={
+              viewType === "list"
+                ? "max-[1100px]:size-8 max-[1100px]:w-24 max-[1100px]:gap-0 max-[1100px]:px-0"
+                : undefined
+            }
+            hideButtonLabelOnCompact={viewType === "list"}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/widgets/employees-list/employees-list.tsx
+++ b/src/widgets/employees-list/employees-list.tsx
@@ -195,6 +195,7 @@ export const EmployeesList = ({
     <div>
       <div className="flex justify-between items-center mb-3">
         <Tabs
+          className="min-w-0 flex-1 overflow-x-auto pb-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           value={activeTab}
           onValueChange={(value) => {
             const tab = value as

--- a/src/widgets/header-user-card/ui/header-user-card.tsx
+++ b/src/widgets/header-user-card/ui/header-user-card.tsx
@@ -47,7 +47,7 @@ export function HeaderUserCard() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger hasArrow>
-        <div className="flex h-[60px] w-[247px] items-center gap-3 rounded-lg  px-2 py-2">
+        <div className="flex h-[60px] max-w-[250px] items-center gap-3 rounded-lg px-1 py-2">
           {/* Аватар */}
           {employee.photo ? (
             <img
@@ -62,11 +62,13 @@ export function HeaderUserCard() {
           )}
 
           {/* Имя и должность */}
-          <div className="flex flex-col gap-1 items-start">
-            <span className="body-m-semibold whitespace-nowrap text-black">
+          <div className="flex flex-col gap-1 items-start min-w-0">
+            <span className="w-full truncate text-start body-m-semibold whitespace-nowrap text-black">
               {employee.name}
             </span>
-            <span className="body-m text-black">{employee.position}</span>
+            <span className="w-full truncate body-m text-start text-black">
+              {employee.position}
+            </span>
           </div>
         </div>
       </DropdownMenuTrigger>

--- a/src/widgets/page-header/ui/page-header.tsx
+++ b/src/widgets/page-header/ui/page-header.tsx
@@ -23,33 +23,41 @@ export function PageHeader({
   return (
     <header
       className={cn(
-        "flex flex-col gap-4 border-b border-gray-200 bg-white px-4 py-4 lg:flex-row lg:items-center lg:justify-between lg:px-8",
+        "flex items-center justify-between gap-5 border-b border-gray-200 bg-white px-4 py-4 lg:px-8",
         className,
       )}
     >
       {/* Левая часть: заголовок + статистика */}
-      <div className="flex flex-col gap-1">
+      <div className="flex shrink-0 flex-col gap-1">
         {title && (
-          <h1 className="font-family-primary text-[24px] font-semibold leading-[32px] text-black lg:text-[32px] lg:leading-[44px]">
+          <h1 className="font-family-primary font-semibold text-black text-[32px] leading-[44px] max-[1100px]:text-[24px]">
             {title}
           </h1>
         )}
-        {stats && <div className="body-s text-gray-600">{stats}</div>}
+        {stats && (
+          <div className="body-s text-gray-600 max-[1100px]:text-xs">
+            {stats}
+          </div>
+        )}
       </div>
 
       {/* Правая часть: поиск + уведомления + профиль */}
-      <div className="flex items-center gap-10">
+      <div className="flex min-w-0 items-center justify-end gap-10 max-[1240px]:gap-6 max-[1100px]:gap-4">
         {/* Поиск */}
-        {search && <div className="w-[356px]">{search}</div>}
+        {search && (
+          <div className="min-w-[180px] w-[356px] max-w-[356px] shrink max-[1180px]:w-[clamp(180px,26vw,356px)]">
+            {search}
+          </div>
+        )}
 
         {/* Birthday (Дни рождения) */}
-        {birthday && birthday}
+        {birthday && <div className="shrink-0">{birthday}</div>}
 
         {/* Профиль пользователя */}
-        {user && user}
+        {user && <div className="shrink-0">{user}</div>}
 
         {/* Дополнительные действия */}
-        {rightActions && rightActions}
+        {rightActions && <div className="shrink-0">{rightActions}</div>}
       </div>
     </header>
   );


### PR DESCRIPTION
таска #141 
1) Добавил переносы кнопок в баре с фильтрами при сужении экрана, когда выбран табличный вид, там добавляется кнопка экспорта, которая занимает место, поэтому в табличном видео сделал кнопки без надписей, чтоб более менее выглядело
<img width="1043" height="383" alt="image" src="https://github.com/user-attachments/assets/91e7dd1e-dc9b-4d75-bd0f-29ccdccaec93" />

2) табам добавил скролл, потому что кнопка переключения не вмещается нормально в эту ширину, а переносить ее - выглядело как-то неочень
3) Поправил страницу орг структуры, там при разрешении 1440 картинка не вписывалась в свою область, а обрезалась, сейчас стоит нормально, при широком экране 1920 становится по центру, занимая всю высоту страницы
4) таблице добавил скролл, но как по мне, на такой ширине не особо смысл имеет отображение таблицы, т.к. плохо читается и нужно скроллить, мб лучше вообще убирать возможность переключить, а оставлять кнопку табличного экспорта только, либо что-то делать с навбаром, он много места съедает
<img width="1036" height="803" alt="image" src="https://github.com/user-attachments/assets/6b25b92d-4eaa-44ed-8f5b-9db944fd3ebf" />

5) поменял лейаут хедера, т.к. при 992 было много пустого пространства
6) подправил лейауты орг структуры и страницы сотрудников, чтоб не было вертикального скролла, когда контента на странице мало
7) в пагинации убрал надпись "карточек на странице" на ширине 1300, оставил только дропдаун