### PR TITLE
feat: dynamic header stats with pluralization #45

### DIFF
--- a/src/entities/org-structure/api/summary-api.ts
+++ b/src/entities/org-structure/api/summary-api.ts
@@ -1,0 +1,12 @@
+import { apiClient } from "@/shared/api/client";
+
+export interface SummaryStats {
+  employees_count: number;
+  directions_count: number;
+  vacancies_count: number;
+}
+
+export const getSummaryStats = async (): Promise<SummaryStats> => {
+  const response = await apiClient.get<SummaryStats>("/admin/summary/");
+  return response.data;
+};

--- a/src/entities/org-structure/index.ts
+++ b/src/entities/org-structure/index.ts
@@ -12,6 +12,8 @@ export type {
 } from "./model/types";
 export { useOrgStructureStore } from "./model/use-org-structure-store";
 export { useOrgStructure } from "./api/use-org-structure";
+export { useSummaryStats, summaryKeys } from "./model/summary-queries";
+export type { SummaryStats } from "./api/summary-api";
 export { 
   useCreateDepartment, 
   useUpdateDepartment,

--- a/src/entities/org-structure/model/summary-queries.ts
+++ b/src/entities/org-structure/model/summary-queries.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { getSummaryStats } from "../api/summary-api";
+
+export const summaryKeys = {
+  all: ["summary"] as const,
+};
+
+export const useSummaryStats = () => {
+  return useQuery({
+    queryKey: summaryKeys.all,
+    queryFn: getSummaryStats,
+    staleTime: 5 * 60 * 1000,
+  });
+};

--- a/src/pages/employees/employees-page.tsx
+++ b/src/pages/employees/employees-page.tsx
@@ -17,6 +17,9 @@ import {
 import { useEmployeeModalStore } from "@/features/employee";
 import { AppPagination } from "@ui/pagination";
 import { useGetVacancyDetail } from "@/entities/vacancy";
+import { useAuthStore } from "@/entities/user";
+import { useSummaryStats } from "@/entities/org-structure";
+import { pluralize } from "@/shared/lib";
 
 const EMPLOYEES_LIMIT_OPTIONS = [6, 12, 24, 50];
 const DEFAULT_EMPLOYEE_LIMIT = 12;
@@ -38,7 +41,9 @@ const EmployeesPage = () => {
   const [offset, setOffset] = useState(0);
   const [vacancyIdFromUrl, setVacancyIdFromUrl] = useState<number | null>(null);
 
-  //TODO: Добавить логику передачи роли в хук
+  const currentUser = useAuthStore((state) => state.user);
+  const currentEmployeeId = currentUser?.employee_id;
+
   const { data: listData, isLoading: isListLoading } = useEmployeesList(
     limit,
     offset,
@@ -46,13 +51,43 @@ const EmployeesPage = () => {
   const { data: vacancyDetailFromUrl } = useGetVacancyDetail(
     vacancyIdFromUrl ?? 0,
   );
+  const { data: summaryData, isLoading: isSummaryLoading } = useSummaryStats();
 
-  const totalCount = listData?.count ?? 0;
+  const totalCount = (listData?.count ?? 0) - (currentEmployeeId ? 1 : 0);
   const page = Math.floor(offset / limit) + 1;
 
   const employees = useMemo(() => {
     return listData?.results ?? [];
   }, [listData?.results]);
+
+  const statsText = useMemo(() => {
+    if (isSummaryLoading) return "Загрузка...";
+    if (!summaryData) return "Нет данных";
+
+    // TODO: #45 Заменить "вакансий" на "СИС" после добавления соответствующего поля в API
+    // Сейчас API возвращает vacancies_count, но в дизайне отображается "СИС"
+    // Нужно будет обновить после доработки бекенда
+    const employees = pluralize(
+      summaryData.employees_count,
+      "сотрудник",
+      "сотрудника",
+      "сотрудников",
+    );
+    const directions = pluralize(
+      summaryData.directions_count,
+      "направление",
+      "направления",
+      "направлений",
+    );
+    const vacancies = pluralize(
+      summaryData.vacancies_count,
+      "вакансия",
+      "вакансии",
+      "вакансий",
+    );
+
+    return `${summaryData.employees_count} ${employees}, ${summaryData.directions_count} ${directions}, ${summaryData.vacancies_count} ${vacancies}`;
+  }, [summaryData, isSummaryLoading]);
 
   //TODO: Обработать сценарий если при редактировании происходит ошибка
   const { mutate: patchEmployee } = usePatchEmployee();
@@ -97,7 +132,7 @@ const EmployeesPage = () => {
       <div className="flex h-full min-h-0 flex-col bg-gray-50">
         <PageHeader
           title="Книга сотрудников"
-          stats={<span>144 сотрудников, 4 направления, 7 СИС</span>}
+          stats={<span>{statsText}</span>}
           search={
             <SearchInput placeholder="Поиск по ФИО, должности, тегам..." />
           }

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,3 +1,4 @@
 export { cn } from "./cn/cn";
 export * from "./hooks";
 export { emailSchema, passwordSchema } from "./validation";
+export { pluralize } from "./pluralize";

--- a/src/shared/lib/pluralize.ts
+++ b/src/shared/lib/pluralize.ts
@@ -1,0 +1,32 @@
+/**
+ * Склоняет слова в зависимости от числа (для русского языка)
+ * @param number - число
+ * @param one - форма для 1 (например, "сотрудник")
+ * @param few - форма для 2-4 (например, "сотрудника")
+ * @param many - форма для 5+ (например, "сотрудников")
+ * @returns правильная форма слова
+ */
+export const pluralize = (
+    number: number,
+    one: string,
+    few: string,
+    many: string,
+  ): string => {
+    const n = Math.abs(number);
+    const lastDigit = n % 10;
+    const lastTwoDigits = n % 100;
+  
+    if (lastTwoDigits >= 11 && lastTwoDigits <= 19) {
+      return many;
+    }
+  
+    if (lastDigit === 1) {
+      return one;
+    }
+  
+    if (lastDigit >= 2 && lastDigit <= 4) {
+      return few;
+    }
+  
+    return many;
+  };


### PR DESCRIPTION
## Что сделано
- Подключен API эндпоинт `/admin/summary/` для получения статистики
- Создан хук `useSummaryStats` с React Query
- Динамическая статистика в хедере вместо статической
- Добавлена правильная плюрализация для русского языка

## Как проверить
1. Зайти на страницу "Книга сотрудников"
2. Убедиться, что в хедере отображаются актуальные данные:
   - Количество сотрудников
   - Количество направлений
   - Количество вакансий
3. Проверить склонение:
   - 1 сотрудник, 2 сотрудника, 5 сотрудников
   - 1 направление, 2 направления, 5 направлений
   - 1 вакансия, 2 вакансии, 5 вакансий

## Известные проблемы/TODO
- Заменить "вакансий" на "СИС" после доработки бекенда (нужно новое поле в API) или вообще убрать "вакансий"?