### PR TITLE
fix(org-structure): add head_id support and cleanup error handling

### DIFF
--- a/src/entities/org-structure/api/use-org-structure.ts
+++ b/src/entities/org-structure/api/use-org-structure.ts
@@ -6,6 +6,8 @@ function mapDepartmentToOrgUnit(data: DepartmentResponse): OrgUnit {
   return {
     id: data.id,
     name: data.name,
+    headId: data.head_id,
+    headName: data.head?.full_name || '',
     employeeCount: data.employee_count,
     items: data.children?.map(mapDepartmentToOrgUnit) || [],
   };

--- a/src/entities/org-structure/model/types.ts
+++ b/src/entities/org-structure/model/types.ts
@@ -2,6 +2,8 @@ export interface OrgUnit {
   id?: number;
   name: string;
   head?: boolean;
+  headId?: number | null;
+  headName?: string;
   employeeCount?: number;
   items?: OrgUnit[];
 }
@@ -9,6 +11,7 @@ export interface OrgUnit {
 export interface DepartmentCreateDTO {
   name: string;
   type: 'direction' | 'sis' | 'department';
+  head_id?: number | null;
   display_order?: number;
   parent?: number | null;
   description?: string;
@@ -18,11 +21,18 @@ export interface DepartmentCreateDTO {
 export interface DepartmentUpdateDTO {
   name?: string;
   type?: 'direction' | 'sis' | 'department';
+  head_id?: number | null;
   display_order?: number;
   parent?: number | null;
   description?: string;
   short_name?: string;
   is_active?: boolean;
+}
+
+export interface HeadInfo {
+  id: number;
+  full_name: string;
+  job_title: string;
 }
 
 export interface DepartmentResponse {
@@ -32,6 +42,8 @@ export interface DepartmentResponse {
   description: string | null;
   type: 'direction' | 'sis' | 'department';
   parent: number | null;
+  head: HeadInfo | null;
+  head_id: number | null;
   display_order: number;
   is_active: boolean;
   employee_count: number;
@@ -43,6 +55,7 @@ export interface DirectionFormValues {
   short_name?: string;
   description: string;
   type: 'direction' | 'sis';
+  head_id?: number | null;
   parent?: number | null;
   display_order?: number;
 }

--- a/src/entities/org-structure/model/use-org-structure-store.ts
+++ b/src/entities/org-structure/model/use-org-structure-store.ts
@@ -37,17 +37,17 @@ export const useOrgStructureStore = create<OrgStructureStore>()((set) => ({
   loadFromTree: (tree) => {
     const directionsNode = tree.find(u => u.name === "Направления");
     const sisNode = tree.find(u => u.name === "СИС");
-  
+
     const directions = directionsNode?.items?.map((item): OrgItemType => ({
       id: String(item.id || ''),
       name: item.name,
-      headName: '',
+      headName: item.headName || '',
     })) || [];
     
     const sisList = sisNode?.items?.map((item): OrgItemType => ({
       id: String(item.id || ''),
       name: item.name,
-      headName: '',
+      headName: item.headName || '',
     })) || [];
     
     set({ tree, directions, sisList });

--- a/src/features/create-direction-modal/ui/create-direction-modal.tsx
+++ b/src/features/create-direction-modal/ui/create-direction-modal.tsx
@@ -53,7 +53,7 @@ export function CreateDirectionModal({
     setOpen(isOpen);
   };
 
-  const handleCreate = async () => {
+  const handleCreate = () => {
     if (!name.trim()) {
       addNotification({
         type: "error",
@@ -64,26 +64,21 @@ export function CreateDirectionModal({
       return;
     }
 
-    try {
-      await createDepartment.mutateAsync({
-        name: name.trim(),
-        type: isDirection ? "direction" : "sis",
-        description: description.trim() || undefined,
-        // Если нужно привязывать к руководителю, добавляем поле head_id
-        // head_id: headId,
-      });
+    createDepartment.mutate({
+      name: name.trim(),
+      type: isDirection ? "direction" : "sis",
+      description: description.trim() || undefined,
+      head_id: headId,
+    });
 
-      handleOpenChange(false);
-      
-      onCreate?.({
-        name,
-        headName,
-        headId,
-        description,
-      });
-    } catch (error) {
-      console.error("Error creating department:", error);
-    }
+    handleOpenChange(false);
+    
+    onCreate?.({
+      name,
+      headName,
+      headId,
+      description,
+    });
   };
 
   const handleNext = () => {

--- a/src/features/edit-direction-modal/ui/edit-direction-modal.tsx
+++ b/src/features/edit-direction-modal/ui/edit-direction-modal.tsx
@@ -54,7 +54,7 @@ export function EditDirectionModal({
     setOpen(isOpen);
   };
 
-  const handleSave = async () => {
+  const handleSave = () => {
     if (!departmentId) {
       addNotification({
         type: "error",
@@ -75,23 +75,18 @@ export function EditDirectionModal({
       return;
     }
 
-    try {
-      await updateDepartment.mutateAsync({
-        id: departmentId,
-        data: {
-          name: name.trim(),
-          description: description.trim() || undefined,
-          // Если нужно обновлять руководителя
-          // head_id: headId,
-        },
-      });
+    updateDepartment.mutate({
+      id: departmentId,
+      data: {
+        name: name.trim(),
+        description: description.trim() || undefined,
+        head_id: headId,
+      },
+    });
 
-      handleOpenChange(false);
-      
-      onSave?.({ name, headName, description }, departments);
-    } catch (error) {
-      console.error("Error updating department:", error);
-    }
+    handleOpenChange(false);
+    
+    onSave?.({ name, headName, description }, departments);
   };
 
   const handleAddDepartment = () => {

--- a/src/widgets/edit-org-structure-modal/edit-org-structure-modal.tsx
+++ b/src/widgets/edit-org-structure-modal/edit-org-structure-modal.tsx
@@ -48,7 +48,7 @@ export function EditOrgStructureModal({
     headName: string;
     entityType: "direction" | "sis";
     departmentId?: number;
-    headId?: number;
+    headId?: number | null;
   } | null>(null);
   const [creatingEntityType, setCreatingEntityType] = useState<
     "direction" | "sis" | null
@@ -132,14 +132,14 @@ export function EditOrgStructureModal({
 
   const handleEditDirection = (item: OrgItemType) => {
     let departmentId: number | undefined;
-    let headId: number | undefined;
+    let headId: number | null = null;
     
     const directionNode = tree.find(u => u.name === "Направления");
     if (directionNode?.items) {
       const found = directionNode.items.find((u: OrgUnit) => String(u.id) === item.id);
       if (found) {
         departmentId = found.id;
-        headId = found.headId;
+        headId = found.headId ?? null;
       }
     }
 
@@ -153,14 +153,14 @@ export function EditOrgStructureModal({
 
   const handleEditSis = (item: OrgItemType) => {
     let departmentId: number | undefined;
-    let headId: number | undefined;
+    let headId: number | null = null;
     
     const sisNode = tree.find(u => u.name === "СИС");
     if (sisNode?.items) {
       const found = sisNode.items.find((u: OrgUnit) => String(u.id) === item.id);
       if (found) {
         departmentId = found.id;
-        headId = found.headId;
+        headId = found.headId ?? null;
       }
     }
 

--- a/src/widgets/edit-org-structure-modal/edit-org-structure-modal.tsx
+++ b/src/widgets/edit-org-structure-modal/edit-org-structure-modal.tsx
@@ -48,6 +48,7 @@ export function EditOrgStructureModal({
     headName: string;
     entityType: "direction" | "sis";
     departmentId?: number;
+    headId?: number;
   } | null>(null);
   const [creatingEntityType, setCreatingEntityType] = useState<
     "direction" | "sis" | null
@@ -85,7 +86,7 @@ export function EditOrgStructureModal({
       return targetNode.items.map((item: OrgUnit): Department => ({
         id: String(item.id || ''),
         name: item.name,
-        headName: '',
+        headName: item.headName || '',
       }));
     };
   }, [tree]);
@@ -131,35 +132,47 @@ export function EditOrgStructureModal({
 
   const handleEditDirection = (item: OrgItemType) => {
     let departmentId: number | undefined;
+    let headId: number | undefined;
+    
     const directionNode = tree.find(u => u.name === "Направления");
     if (directionNode?.items) {
       const found = directionNode.items.find((u: OrgUnit) => String(u.id) === item.id);
-      if (found?.id) departmentId = found.id;
+      if (found) {
+        departmentId = found.id;
+        headId = found.headId;
+      }
     }
 
     setEditingDirection({ 
       ...item, 
       entityType: "direction",
-      departmentId 
+      departmentId,
+      headId,
     });
   };
 
   const handleEditSis = (item: OrgItemType) => {
     let departmentId: number | undefined;
+    let headId: number | undefined;
+    
     const sisNode = tree.find(u => u.name === "СИС");
     if (sisNode?.items) {
       const found = sisNode.items.find((u: OrgUnit) => String(u.id) === item.id);
-      if (found?.id) departmentId = found.id;
+      if (found) {
+        departmentId = found.id;
+        headId = found.headId;
+      }
     }
 
     setEditingDirection({ 
       ...item, 
       entityType: "sis",
-      departmentId 
+      departmentId,
+      headId,
     });
   };
 
-  const handleDeleteDirection = async (item: OrgItemType) => {
+  const handleDeleteDirection = (item: OrgItemType) => {
     if (onDeleteDirection) {
       onDeleteDirection(item);
       return;
@@ -182,20 +195,16 @@ export function EditOrgStructureModal({
       return;
     }
 
-    try {
-      await deleteDepartment.mutateAsync(departmentId);
-      setLocalDirections((items) => items.filter((i) => i.id !== item.id));
-      addNotification({
-        iconType: "success",
-        title: "Удалено",
-        message: `«${item.name}» удалено`,
-      });
-    } catch (error) {
-      console.error("Error deleting direction:", error);
-    }
+    deleteDepartment.mutate(departmentId);
+    setLocalDirections((items) => items.filter((i) => i.id !== item.id));
+    addNotification({
+      iconType: "success",
+      title: "Удалено",
+      message: `«${item.name}» удалено`,
+    });
   };
 
-  const handleDeleteSis = async (item: OrgItemType) => {
+  const handleDeleteSis = (item: OrgItemType) => {
     if (onDeleteSis) {
       onDeleteSis(item);
       return;
@@ -218,17 +227,13 @@ export function EditOrgStructureModal({
       return;
     }
 
-    try {
-      await deleteDepartment.mutateAsync(departmentId);
-      setLocalSisList((items) => items.filter((i) => i.id !== item.id));
-      addNotification({
-        iconType: "success",
-        title: "Удалено",
-        message: `«${item.name}» удалено`,
-      });
-    } catch (error) {
-      console.error("Error deleting sis:", error);
-    }
+    deleteDepartment.mutate(departmentId);
+    setLocalSisList((items) => items.filter((i) => i.id !== item.id));
+    addNotification({
+      iconType: "success",
+      title: "Удалено",
+      message: `«${item.name}» удалено`,
+    });
   };
 
   const handleDirectionSave = (values: DirectionFormValues) => {
@@ -339,6 +344,7 @@ export function EditOrgStructureModal({
         entityType={editingDirection?.entityType}
         initialName={editingDirection?.name ?? ""}
         initialHeadName={editingDirection?.headName ?? ""}
+        initialHeadId={editingDirection?.headId ?? null}
         departments={editingDepartments}
         departmentId={editingDirection?.departmentId}
         onSave={handleDirectionSave}


### PR DESCRIPTION
- Add head_id field to DepartmentCreateDTO and DepartmentUpdateDTO
- Update create and edit modals to send head_id to API
- Remove redundant try/catch blocks (errors handled in mutations)
- Update types with HeadInfo interface
- Fix data synchronization in modals with useEffect
- Pass headId to EditDirectionModal from EditOrgStructureModal